### PR TITLE
Fix typo folowing->following.

### DIFF
--- a/Homework/Merge/Merge/merge.org
+++ b/Homework/Merge/Merge/merge.org
@@ -12,7 +12,7 @@ Read section 3.2 and 7.8.  Honestly, most of the commands you'll
 actually use in this code are from 3.2, but there's a lot of good
 stuff in 7.8.
 
-You are responsible for memorizing the meaning/use of the folowing commands:
+You are responsible for memorizing the meaning/use of the following commands:
 
 : git merge
 

--- a/Homework/Merge/README.md
+++ b/Homework/Merge/README.md
@@ -8,7 +8,7 @@ Read section 3.2 and 7.8.  Honestly, most of the commands you'll
 actually use in this code are from 3.2, but there's a lot of good
 stuff in 7.8.
 
-You are responsible for memorizing the meaning/use of the folowing commands:
+You are responsible for memorizing the meaning/use of the following commands:
 
     git merge
 

--- a/Homework/Plumbing1/README.md
+++ b/Homework/Plumbing1/README.md
@@ -11,7 +11,7 @@ the example.  I recommend you use a unix environment for this course -
 but something like cygwin that simlates unix on windows should
 probably work fine as well.
 
-You are responsible for memorizing the meaning/use of the folowing commands:
+You are responsible for memorizing the meaning/use of the following commands:
 
     git hash-object -w --stdin
     git cat-file -p

--- a/Homework/Plumbing2/README.md
+++ b/Homework/Plumbing2/README.md
@@ -6,7 +6,7 @@ layout: github
 
 Read section 10.3 of the git book.
 
-You are responsible for memorizing the meaning/use of the folowing commands:
+You are responsible for memorizing the meaning/use of the following commands:
 
     git commit-tree
     git update-ref


### PR DESCRIPTION
For some reason CSpell doesn't pick this up as a typo?

No, this commit was not made with the git plumbing commands we learned in class.