### PR TITLE
Fix codeblock formatting not being applied to `grep-tree-contents`

### DIFF
--- a/Homework/Plumbing1/README.md
+++ b/Homework/Plumbing1/README.md
@@ -79,5 +79,4 @@ You will turn in via Moodle.  You must turn in 2 things:
 1.  The source code of your script
 2.  The a text file with the results of running the following search on js-parsons:
 
-    ../grep-tree-contents.rb -t 7d3b207 -s NOTE
-
+        ../grep-tree-contents.rb -t 7d3b207 -s NOTE


### PR DESCRIPTION
Seems to have happened because it was preceded by a numbered list

Before:
![image](https://user-images.githubusercontent.com/25965766/204954885-ab3ed5e1-b7b6-468f-b4f5-43882c8c0c6f.png)

After:
![image](https://user-images.githubusercontent.com/25965766/204955276-72cb4f74-493c-4406-b0c7-939405dd21f2.png)
